### PR TITLE
build: Add Flag to Use Oracle JDK on Codefire

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -182,10 +182,11 @@ endif
 #
 # For Java 1.7, we require OpenJDK on linux and Oracle JDK on Mac OS.
 requires_openjdk := false
+ifneq ($(BUILDING_ON_CODEFIRE),true)
 ifeq ($(HOST_OS), linux)
 requires_openjdk := true
 endif
-
+endif
 
 # Check for the current jdk
 ifeq ($(requires_openjdk), true)


### PR DESCRIPTION
- Works just fine, easier to deploy Oracle JDK Locally

Signed-off-by: Paul Keith javelinanddart@gmail.com
Signed-off-by: Mattia D'Alleva antaresone@antaresone.eu
